### PR TITLE
Added Dataframe output Component

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -335,10 +335,12 @@ app_ui = ui.page_navbar(
 def server(input, output, session):
     qc_vals = qc.server()
 
+    @output
     @render.data_frame
     def data_table():
-        return qc_vals.df()
-
+        return render.DataGrid(qc_vals.df(), height="420px")
+    
+    @output
     @render.text
     def title():
         return qc_vals.title() or "Mars Weather Data"


### PR DESCRIPTION
The AI chat interface was already in place and returning a filtered subset of the Mars weather dataset based on the user’s prompt; this adds the missing piece by showing that filtered dataset directly on the AI tab as an interactive dataframe table that updates after each AI query, with a simple title header above it for context. Lmk for any changes. Thanks!

fix for #51 