### PR TITLE
Output component visualizations

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -314,10 +314,18 @@ app_ui = ui.page_navbar(
                     ui.tags.hr(style=TOP_RULE_STYLE),
                     ui.page_sidebar(
                         qc.sidebar(),
-                        ui.card(
-                            ui.card_header(ui.output_text("title")),
-                            ui.output_data_frame("data_table"),
-                            fill=True,
+                        ui.div(
+                            ui.card(
+                                ui.card_header(ui.output_text("title")),
+                                ui.output_data_frame("data_table"),
+                                fill=True,
+                            ),
+                            ui.layout_columns(
+                                ui.card(ui.output_plot("ai_pressure_min_temp_plot"), style=PLOT_CARD_STYLE),
+                                ui.card(ui.output_plot("ai_temp_series_plot"), style=PLOT_CARD_STYLE),
+                                col_widths=(6, 6),
+                            ),
+                            style="display:flex; flex-direction:column; gap:14px;",
                         ),
                         fillable=True,
                     ),
@@ -339,6 +347,26 @@ def server(input, output, session):
     @render.data_frame
     def data_table():
         return render.DataGrid(qc_vals.df(), height="420px")
+    
+
+    @output
+    @render.plot
+    def ai_pressure_min_temp_plot():
+        d = qc_vals.df()
+        if d is None or d.empty:
+            plt.figure()
+            plt.title("Air Pressure vs Minimum Temperature (AI Filtered)")
+            plt.text(0.5, 0.5, "No data for current AI filter", ha="center", va="center")
+            plt.axis("off")
+            return
+
+    plt.figure()
+    sns.scatterplot(x="pressure", y="min_temp", data=d, color="#FFAD70")
+    plt.ylabel("Min Temperature (C)")
+    plt.xlabel("Air Pressure (Pa)")
+    plt.title("Air Pressure vs Minimum Temperature (AI Filtered)")
+    plt.xticks(rotation=0)
+
     
     @output
     @render.text

--- a/src/app.py
+++ b/src/app.py
@@ -348,7 +348,7 @@ def server(input, output, session):
     def data_table():
         return render.DataGrid(qc_vals.df(), height="420px")
     
-
+    # AI Page Vizualizations
     @output
     @render.plot
     def ai_pressure_min_temp_plot():
@@ -360,12 +360,43 @@ def server(input, output, session):
             plt.axis("off")
             return
 
-    plt.figure()
-    sns.scatterplot(x="pressure", y="min_temp", data=d, color="#FFAD70")
-    plt.ylabel("Min Temperature (C)")
-    plt.xlabel("Air Pressure (Pa)")
-    plt.title("Air Pressure vs Minimum Temperature (AI Filtered)")
-    plt.xticks(rotation=0)
+        plt.figure()
+        sns.scatterplot(x="pressure", y="min_temp", data=d, color="#FFAD70")
+        plt.ylabel("Min Temperature (C)")
+        plt.xlabel("Air Pressure (Pa)")
+        plt.title("Air Pressure vs Minimum Temperature (AI Filtered)")
+        plt.xticks(rotation=0)
+
+
+    @output
+    @render.plot
+    def ai_temp_series_plot():
+        d = qc_vals.df()
+        if d is None or d.empty:
+            plt.figure()
+            plt.title("Daily Average Temperatures (AI Filtered)")
+            plt.text(0.5, 0.5, "No data for current AI filter", ha="center", va="center")
+            plt.axis("off")
+            return
+
+
+        dd = d.copy()
+        dd["terrestrial_date"] = pd.to_datetime(dd["terrestrial_date"])
+        dd = (
+            dd.set_index("terrestrial_date")[["min_temp", "max_temp"]]
+            .resample("1D")
+            .mean()
+            .reset_index()
+        )
+
+        plt.figure(figsize=(10, 6))
+        plt.plot(dd["terrestrial_date"], dd["min_temp"], label="Minimum Temperature", color="#FFAD70")
+        plt.plot(dd["terrestrial_date"], dd["max_temp"], label="Maximum Temperature", color="#C1440E")
+        plt.ylabel("Temperature (C)")
+        plt.xlabel("Terrestrial date")
+        plt.title("Daily Average Temperatures (AI Filtered)")
+        plt.xticks(rotation=90)
+        plt.legend()
 
     
     @output

--- a/src/app.py
+++ b/src/app.py
@@ -335,10 +335,12 @@ app_ui = ui.page_navbar(
 def server(input, output, session):
     qc_vals = qc.server()
 
+    @output
     @render.data_frame
     def data_table():
-        return qc_vals.df()
-
+        return render.DataGrid(qc_vals.df(), height="420px")
+    
+    @output
     @render.text
     def title():
         return qc_vals.title() or "Mars Weather Data"

--- a/src/app.py
+++ b/src/app.py
@@ -320,11 +320,8 @@ app_ui = ui.page_navbar(
                                 ui.output_data_frame("data_table"),
                                 fill=True,
                             ),
-                            ui.layout_columns(
-                                ui.card(ui.output_plot("ai_pressure_min_temp_plot"), style=PLOT_CARD_STYLE),
-                                ui.card(ui.output_plot("ai_temp_series_plot"), style=PLOT_CARD_STYLE),
-                                col_widths=(6, 6),
-                            ),
+                            ui.card(ui.output_plot("ai_pressure_min_temp_plot"), style=PLOT_CARD_STYLE),
+                            ui.card(ui.output_plot("ai_temp_series_plot"), style=PLOT_CARD_STYLE),
                             style="display:flex; flex-direction:column; gap:14px;",
                         ),
                         fillable=True,


### PR DESCRIPTION
Added two additional visual outputs that update from the same AI filtered dataset after each query: (1) a pressure vs minimum temperature scatterplot, and (2) a daily min and max temperature time series. Lmk for any changes. Thanks!

<img width="1389" height="817" alt="Screenshot 2026-03-06 at 4 43 18 PM" src="https://github.com/user-attachments/assets/9ee10dbc-5e60-43d6-b2ab-295a7c2ee7f7" />



Fix for #52 