### PR TITLE
remove logic import

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -12,7 +12,6 @@ import shinychat
 import narwhals.stable.v1 as nw
 import os
 from faicons import icon_svg
-from logic import compare
 import ibis
 from ibis import _
 


### PR DESCRIPTION
The line `from logic import compare` was causing issues for the posit deployment and since we have the function also defined in the app.py script it is unnecessary. This PR is just a small change but should return our deployment to being functional!